### PR TITLE
исправленны критические недочёты взаимодействия с websocket и stomp

### DIFF
--- a/src/main/java/com/zvonok/config/WebSocketConfig.java
+++ b/src/main/java/com/zvonok/config/WebSocketConfig.java
@@ -1,21 +1,31 @@
 package com.zvonok.config;
 
+import com.zvonok.handler.JwtChannelInterceptor;
 import com.zvonok.handler.JwtHandshakeHandler;
 import com.zvonok.handler.JwtHandshakeInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+	private final JwtChannelInterceptor jwtChannelInterceptor;
     private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
     private final JwtHandshakeHandler jwtHandshakeHandler;
+
+	@Override
+	public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+		registration.setMessageSizeLimit(32 * 1024);
+		registration.setTimeToFirstMessage(30000);
+	}
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -23,6 +33,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         config.enableSimpleBroker("/topic", "/queue");
         config.setUserDestinationPrefix("/user");
     }
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(jwtChannelInterceptor);
+	}
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {

--- a/src/main/java/com/zvonok/controller/ChatController.java
+++ b/src/main/java/com/zvonok/controller/ChatController.java
@@ -3,10 +3,14 @@ package com.zvonok.controller;
 import com.zvonok.controller.dto.ChannelMessageResponse;
 import com.zvonok.controller.dto.MessageResponse;
 import com.zvonok.exception.AuthenticatedPrincipalRequiredException;
+import com.zvonok.exception_handler.annotation.ApiException;
 import com.zvonok.exception_handler.enumeration.BusinessRuleMessage;
 import com.zvonok.service.MessageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
@@ -50,6 +54,12 @@ public class ChatController {
         return messageService.sendChannelMessage(sender, channelId, content);
     }
 
+	@MessageExceptionHandler()
+	public void exceptionMessage(Exception ex, Principal principal, Message<?> message) {
+		String username = principal != null ? principal.getName(): null;
+		messageService.sendErrorMessage(username, ex.getMessage(), getStatusFromException(ex));
+	}
+
     private String resolvePrincipalName(Principal principal) {
         if (principal == null || principal.getName() == null) {
             throw new AuthenticatedPrincipalRequiredException(
@@ -57,6 +67,11 @@ public class ChatController {
         }
         return principal.getName();
     }
+
+	private HttpStatus getStatusFromException(Exception ex) {
+		ApiException apiException = ex.getClass().getAnnotation(ApiException.class);
+		return apiException != null ? apiException.status(): HttpStatus.INTERNAL_SERVER_ERROR;  
+	}
 
     private void validateContent(String content) {
         if (content == null || content.trim().isEmpty()) {

--- a/src/main/java/com/zvonok/controller/dto/ChatErrorMessageResponse.java
+++ b/src/main/java/com/zvonok/controller/dto/ChatErrorMessageResponse.java
@@ -1,0 +1,9 @@
+package com.zvonok.controller.dto;
+
+import lombok.Data;
+
+@Data
+public class ChatErrorMessageResponse {
+	String message;
+	int status;
+}

--- a/src/main/java/com/zvonok/exception_handler/enumeration/HttpResponseMessage.java
+++ b/src/main/java/com/zvonok/exception_handler/enumeration/HttpResponseMessage.java
@@ -65,7 +65,8 @@ public enum HttpResponseMessage {
     HTTP_REFRESH_TOKEN_EXPIRED_RESPONSE_MESSAGE("Refresh token has expired"),
     HTTP_REFRESH_TOKEN_REVOKED_RESPONSE_MESSAGE("Refresh token is revoked"),
     HTTP_REDEFINITION_RESPONSE_MESSAGE("Override can be either for the role or for the user"),
-    HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE("Message was not found");
+    HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE("Message was not found"),
+	HTTP_AUTH_PRINCEPAL_REQUIRED_RESPONSE_MESSAGE("Authenticated principal required for this WebSocket operation");
 
     private final String message;
 

--- a/src/main/java/com/zvonok/handler/JwtChannelInterceptor.java
+++ b/src/main/java/com/zvonok/handler/JwtChannelInterceptor.java
@@ -1,0 +1,52 @@
+package com.zvonok.handler;
+
+import java.security.Principal;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+import com.zvonok.exception.AuthenticatedPrincipalRequiredException;
+import com.zvonok.exception.InvalidJwtException;
+import com.zvonok.exception_handler.enumeration.HttpResponseMessage;
+import com.zvonok.security.JwtTokenProvider;
+import com.zvonok.security.dto.UserPrincipal;
+import lombok.AllArgsConstructor;
+
+@Component
+@AllArgsConstructor
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+		Principal principal = accessor.getUser();
+
+		if (accessor.getCommand() == null) {
+			return message;
+		}
+
+		switch (accessor.getCommand()) {
+			case CONNECT, DISCONNECT:
+				return message;
+			default:
+				if (principal == null) {
+					throw new AuthenticatedPrincipalRequiredException(
+							HttpResponseMessage.HTTP_AUTH_PRINCEPAL_REQUIRED_RESPONSE_MESSAGE
+									.getMessage());
+				}
+
+				if (principal instanceof UserPrincipal userPrincipal) {
+					if (!jwtTokenProvider.isValidToken(userPrincipal.getToken())) {
+						throw new InvalidJwtException(
+								HttpResponseMessage.HTTP_INVALID_JWT_RESPONSE_MESSAGE.getMessage());
+					}
+				}
+		}
+
+		return message;
+	}
+
+}

--- a/src/main/java/com/zvonok/handler/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/zvonok/handler/JwtHandshakeInterceptor.java
@@ -26,7 +26,6 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 			WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
 
 		String token = extractToken(request);
-		System.out.println(token);
 
 		if (token != null && !token.isEmpty() && jwtTokenProvider.isValidToken(token)) {
 			String username = jwtTokenProvider.getUsername(token);
@@ -46,7 +45,7 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 			response.getHeaders().set("X-WS-Error", "TOKEN_INVALID");
 			return false;
 		}
-
+		
 		return false;
 	}
 

--- a/src/main/java/com/zvonok/handler/WebSocketEventListener.java
+++ b/src/main/java/com/zvonok/handler/WebSocketEventListener.java
@@ -1,0 +1,41 @@
+package com.zvonok.handler;
+
+import java.security.Principal;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import com.zvonok.service.WebSocketActiveSessionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketEventListener {
+
+	private final WebSocketActiveSessionService sessionService;
+
+	@EventListener
+	public void handleSessionConnect(SessionConnectEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		Principal principal = accessor.getUser();
+		String sessionId = accessor.getSessionId();
+
+		if (principal != null && sessionId != null) {
+			sessionService.addSession(principal.getName(), sessionId);
+		}
+	}
+
+	@EventListener
+	public void handleSessionDisconnect(SessionDisconnectEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = accessor.getSessionId();
+
+		if (sessionId != null) {
+			sessionService.removeSession(sessionId);
+		}
+		log.info("Disconnect sessionId=" + sessionId + ", closeStatus=" + event.getCloseStatus());
+	}
+}

--- a/src/main/java/com/zvonok/service/MessageService.java
+++ b/src/main/java/com/zvonok/service/MessageService.java
@@ -1,6 +1,7 @@
 package com.zvonok.service;
 
 import com.zvonok.controller.dto.ChannelMessageResponse;
+import com.zvonok.controller.dto.ChatErrorMessageResponse;
 import com.zvonok.exception.CannotEditDeletedMessageException;
 import com.zvonok.exception.InsufficientPermissionsException;
 import com.zvonok.exception.MessageNotFoundException;
@@ -16,6 +17,7 @@ import com.zvonok.model.enumeration.MessageType;
 import com.zvonok.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,8 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Service for managing messages in private rooms, group rooms, and channels.
- * Сервис для управления сообщениями в приватных комнатах, групповых комнатах и каналах.
+ * Service for managing messages in private rooms, group rooms, and channels. Сервис для управления
+ * сообщениями в приватных комнатах, групповых комнатах и каналах.
  */
 @Service
 @RequiredArgsConstructor
@@ -34,243 +36,254 @@ import java.util.List;
 @Slf4j
 public class MessageService {
 
-    private final MessageRepository messageRepository;
-    private final SimpMessagingTemplate messagingTemplate;
-    private final RoomService roomService;
-    private final UserService userService;
-    private final ChannelService channelService;
-    private final PermissionService permissionService;
+	private final MessageRepository messageRepository;
+	private final SimpMessagingTemplate messagingTemplate;
+	private final RoomService roomService;
+	private final UserService userService;
+	private final ChannelService channelService;
+	private final PermissionService permissionService;
 
-    public MessageResponse sendPrivateMessage(String senderUsername, String receiverUsername, String content) {
-        log.info("📤 Sending private message from {} to {}: {}", senderUsername, receiverUsername, content);
-        
-        Room privateRoom = roomService.createOrGetPrivateRoom(senderUsername, receiverUsername);
-        User sender = userService.getUser(senderUsername);
+	public MessageResponse sendPrivateMessage(String senderUsername, String receiverUsername,
+			String content) {
+		log.info("📤 Sending private message from {} to {}: {}", senderUsername, receiverUsername,
+				content);
 
-        // Проверяем, что отправитель является участником комнаты
-        boolean isMember = privateRoom.getMembers().stream()
-                .anyMatch(member -> member.getId().equals(sender.getId()));
-        if (!isMember) {
-            log.error("❌ User {} is not a member of the private room", senderUsername);
-            throw new InsufficientPermissionsException(
-                    BusinessRuleMessage.BUSINESS_USER_NOT_MEMBER_PRIVATE_ROOM_MESSAGE.getMessage());
-        }
+		Room privateRoom = roomService.createOrGetPrivateRoom(senderUsername, receiverUsername);
+		User sender = userService.getUser(senderUsername);
 
-        Message message = createMessage(sender, content, privateRoom, null);
-        Message savedMessage = messageRepository.save(message);
-        log.info("💾 Message saved with id: {}", savedMessage.getId());
+		// Проверяем, что отправитель является участником комнаты
+		boolean isMember = privateRoom.getMembers().stream()
+				.anyMatch(member -> member.getId().equals(sender.getId()));
+		if (!isMember) {
+			log.error("❌ User {} is not a member of the private room", senderUsername);
+			throw new InsufficientPermissionsException(
+					BusinessRuleMessage.BUSINESS_USER_NOT_MEMBER_PRIVATE_ROOM_MESSAGE.getMessage());
+		}
 
-        MessageResponse response = mapToMessageResponse(savedMessage, privateRoom.getId());
-        response.setEventType(EventType.MESSAGE);
+		Message message = createMessage(sender, content, privateRoom, null);
+		Message savedMessage = messageRepository.save(message);
+		log.info("💾 Message saved with id: {}", savedMessage.getId());
 
-        privateRoom.getMembers().forEach(member -> {
-            log.info("📨 Sending message to user: {}", member.getUsername());
-            messagingTemplate.convertAndSendToUser(
-                    member.getUsername(),
-                    "/queue/messages",
-                    response
-            );
-        });
+		MessageResponse response = mapToMessageResponse(savedMessage, privateRoom.getId());
+		response.setEventType(EventType.MESSAGE);
 
-        log.info("✅ Private message sent successfully");
-        return response;
-    }
+		privateRoom.getMembers().forEach(member -> {
+			log.info("📨 Sending message to user: {}", member.getUsername());
+			messagingTemplate.convertAndSendToUser(member.getUsername(), "/queue/messages",
+					response);
+		});
 
-    public MessageResponse sendGroupMessage(String senderUsername, long roomId, String content) {
-        Room groupRoom = roomService.getRoom(roomId, senderUsername);
-        User sender = userService.getUser(senderUsername);
+		log.info("✅ Private message sent successfully");
+		return response;
+	}
 
-        // Проверяем, что отправитель является участником комнаты
-        boolean isMember = groupRoom.getMembers().stream()
-                .anyMatch(member -> member.getId().equals(sender.getId()));
-        if (!isMember) {
-            throw new InsufficientPermissionsException(
-                    BusinessRuleMessage.BUSINESS_USER_NOT_MEMBER_GROUP_ROOM_MESSAGE.getMessage());
-        }
+	public MessageResponse sendGroupMessage(String senderUsername, long roomId, String content) {
+		Room groupRoom = roomService.getRoom(roomId, senderUsername);
+		User sender = userService.getUser(senderUsername);
 
-        Message message = createMessage(sender, content, groupRoom, null);
-        Message savedMessage = messageRepository.save(message);
+		// Проверяем, что отправитель является участником комнаты
+		boolean isMember = groupRoom.getMembers().stream()
+				.anyMatch(member -> member.getId().equals(sender.getId()));
+		if (!isMember) {
+			throw new InsufficientPermissionsException(
+					BusinessRuleMessage.BUSINESS_USER_NOT_MEMBER_GROUP_ROOM_MESSAGE.getMessage());
+		}
 
-        MessageResponse response = mapToMessageResponse(savedMessage, groupRoom.getId());
-        response.setEventType(EventType.MESSAGE);
+		Message message = createMessage(sender, content, groupRoom, null);
+		Message savedMessage = messageRepository.save(message);
 
-        messagingTemplate.convertAndSend("/topic/room." + groupRoom.getId(), response);
+		MessageResponse response = mapToMessageResponse(savedMessage, groupRoom.getId());
+		response.setEventType(EventType.MESSAGE);
 
-        return response;
-    }
+		messagingTemplate.convertAndSend("/topic/room." + groupRoom.getId(), response);
 
-    public ChannelMessageResponse sendChannelMessage(String senderUsername, Long channelId, String content) {
-        try {
-            User sender = userService.getUser(senderUsername);
-            Channel channel = channelService.getChannel(channelId);
+		return response;
+	}
 
-            if (!permissionService.canUserSendMessages(sender.getId(), channelId)) {
-                throw new InsufficientPermissionsException(
-                        HttpResponseMessage.HTTP_INSUFFICIENT_PERMISSIONS_RESPONSE_MESSAGE.getMessage());
-            }
+	public ChannelMessageResponse sendChannelMessage(String senderUsername, Long channelId,
+			String content) {
+		try {
+			User sender = userService.getUser(senderUsername);
+			Channel channel = channelService.getChannel(channelId);
 
-            Message message = createMessage(sender, content, null, channel);
-            Message savedMessage = messageRepository.save(message);
+			if (!permissionService.canUserSendMessages(sender.getId(), channelId)) {
+				throw new InsufficientPermissionsException(
+						HttpResponseMessage.HTTP_INSUFFICIENT_PERMISSIONS_RESPONSE_MESSAGE
+								.getMessage());
+			}
 
-            ChannelMessageResponse response = mapToChannelMessageResponse(savedMessage, channel);
-            response.setEventType(EventType.MESSAGE);
+			Message message = createMessage(sender, content, null, channel);
+			Message savedMessage = messageRepository.save(message);
 
-            String topicDestination = "/topic/channel." + channelId;
-            messagingTemplate.convertAndSend(topicDestination, response);
+			ChannelMessageResponse response = mapToChannelMessageResponse(savedMessage, channel);
+			response.setEventType(EventType.MESSAGE);
 
-            return response;
+			String topicDestination = "/topic/channel." + channelId;
+			messagingTemplate.convertAndSend(topicDestination, response);
 
-        } catch (Exception e) {
-            log.error("❌ Error sending channel message: {}", e.getMessage(), e);
-            throw e;
-        }
-    }
+			return response;
 
-    @Transactional
-    public MessageResponse editMessage(Long messageId, String senderUsername, String newContent) {
-        Message message = messageRepository.findById(messageId)
-                .orElseThrow(() -> new MessageNotFoundException(
-                        String.format("%s (ID: %d)",
-                                HttpResponseMessage.HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE.getMessage(),
-                                messageId)));
+		} catch (Exception e) {
+			log.error("❌ Error sending channel message: {}", e.getMessage(), e);
+			throw e;
+		}
+	}
 
-        User sender = userService.getUser(senderUsername);
+	@Transactional
+	public MessageResponse editMessage(Long messageId, String senderUsername, String newContent) {
+		Message message = messageRepository.findById(messageId)
+				.orElseThrow(() -> new MessageNotFoundException(String.format("%s (ID: %d)",
+						HttpResponseMessage.HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE.getMessage(),
+						messageId)));
 
-        // Проверяем, что пользователь является отправителем
-        if (!message.getSender().getId().equals(sender.getId())) {
-            throw new InsufficientPermissionsException(
-                    BusinessRuleMessage.BUSINESS_ONLY_SENDER_CAN_EDIT_MESSAGE.getMessage());
-        }
+		User sender = userService.getUser(senderUsername);
 
-        // Проверяем, что сообщение не удалено
-        if (message.isDeleted()) {
-            throw new CannotEditDeletedMessageException(
-                    BusinessRuleMessage.BUSINESS_CANNOT_EDIT_DELETED_MESSAGE.getMessage());
-        }
+		// Проверяем, что пользователь является отправителем
+		if (!message.getSender().getId().equals(sender.getId())) {
+			throw new InsufficientPermissionsException(
+					BusinessRuleMessage.BUSINESS_ONLY_SENDER_CAN_EDIT_MESSAGE.getMessage());
+		}
 
-        message.setContent(newContent);
-        message.setEditedAt(LocalDateTime.now());
-        Message savedMessage = messageRepository.save(message);
+		// Проверяем, что сообщение не удалено
+		if (message.isDeleted()) {
+			throw new CannotEditDeletedMessageException(
+					BusinessRuleMessage.BUSINESS_CANNOT_EDIT_DELETED_MESSAGE.getMessage());
+		}
 
-        MessageResponse response = mapToMessageResponse(savedMessage, 
-                savedMessage.getRoom() != null ? savedMessage.getRoom().getId() : null);
-        response.setEventType(EventType.MESSAGE_EDIT);
+		message.setContent(newContent);
+		message.setEditedAt(LocalDateTime.now());
+		Message savedMessage = messageRepository.save(message);
 
-        // Отправляем обновление через WebSocket
-        if (savedMessage.getRoom() != null) {
-            messagingTemplate.convertAndSend("/topic/room." + savedMessage.getRoom().getId(), response);
-        } else if (savedMessage.getChannel() != null) {
-            ChannelMessageResponse channelResponse = mapToChannelMessageResponse(savedMessage, savedMessage.getChannel());
-            channelResponse.setEventType(EventType.MESSAGE_EDIT);
-            messagingTemplate.convertAndSend("/topic/channel." + savedMessage.getChannel().getId(), channelResponse);
-        }
+		MessageResponse response = mapToMessageResponse(savedMessage,
+				savedMessage.getRoom() != null ? savedMessage.getRoom().getId() : null);
+		response.setEventType(EventType.MESSAGE_EDIT);
 
-        return response;
-    }
+		// Отправляем обновление через WebSocket
+		if (savedMessage.getRoom() != null) {
+			messagingTemplate.convertAndSend("/topic/room." + savedMessage.getRoom().getId(),
+					response);
+		} else if (savedMessage.getChannel() != null) {
+			ChannelMessageResponse channelResponse =
+					mapToChannelMessageResponse(savedMessage, savedMessage.getChannel());
+			channelResponse.setEventType(EventType.MESSAGE_EDIT);
+			messagingTemplate.convertAndSend("/topic/channel." + savedMessage.getChannel().getId(),
+					channelResponse);
+		}
 
-    @Transactional
-    public void deleteMessage(Long messageId, String username) {
-        Message message = messageRepository.findById(messageId)
-                .orElseThrow(() -> new MessageNotFoundException(
-                        String.format("%s (ID: %d)",
-                                HttpResponseMessage.HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE.getMessage(),
-                                messageId)));
+		return response;
+	}
 
-        User user = userService.getUser(username);
+	@Transactional
+	public void deleteMessage(Long messageId, String username) {
+		Message message = messageRepository.findById(messageId)
+				.orElseThrow(() -> new MessageNotFoundException(String.format("%s (ID: %d)",
+						HttpResponseMessage.HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE.getMessage(),
+						messageId)));
 
-        // Проверяем, что пользователь является отправителем или имеет права администратора
-        boolean isSender = message.getSender().getId().equals(user.getId());
-        boolean isAdmin = false;
+		User user = userService.getUser(username);
 
-        if (message.getChannel() != null) {
-            isAdmin = permissionService.hasPermissionInServer(user.getId(), 
-                    message.getChannel().getFolder().getServer().getId(), 
-                    com.zvonok.service.dto.Permission.ADMINISTRATOR);
-        }
+		// Проверяем, что пользователь является отправителем или имеет права администратора
+		boolean isSender = message.getSender().getId().equals(user.getId());
+		boolean isAdmin = false;
 
-        if (!isSender && !isAdmin) {
-            throw new InsufficientPermissionsException(
-                    HttpResponseMessage.HTTP_INSUFFICIENT_PERMISSIONS_RESPONSE_MESSAGE.getMessage());
-        }
+		if (message.getChannel() != null) {
+			isAdmin = permissionService.hasPermissionInServer(user.getId(),
+					message.getChannel().getFolder().getServer().getId(),
+					com.zvonok.service.dto.Permission.ADMINISTRATOR);
+		}
 
-        message.setDeletedAt(LocalDateTime.now());
-        messageRepository.save(message);
+		if (!isSender && !isAdmin) {
+			throw new InsufficientPermissionsException(
+					HttpResponseMessage.HTTP_INSUFFICIENT_PERMISSIONS_RESPONSE_MESSAGE
+							.getMessage());
+		}
 
-        // Отправляем событие удаления через WebSocket
-        if (message.getRoom() != null) {
-            MessageResponse response = mapToMessageResponse(message, message.getRoom().getId());
-            response.setEventType(EventType.MESSAGE_DELETE);
-            messagingTemplate.convertAndSend("/topic/room." + message.getRoom().getId(), response);
-        } else if (message.getChannel() != null) {
-            ChannelMessageResponse response = mapToChannelMessageResponse(message, message.getChannel());
-            response.setEventType(EventType.MESSAGE_DELETE);
-            messagingTemplate.convertAndSend("/topic/channel." + message.getChannel().getId(), response);
-        }
-    }
+		message.setDeletedAt(LocalDateTime.now());
+		messageRepository.save(message);
 
-    public Message getMessage(Long messageId) {
-        return messageRepository.findById(messageId)
-                .orElseThrow(() -> new MessageNotFoundException(
-                        String.format("%s (ID: %d)",
-                                HttpResponseMessage.HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE.getMessage(),
-                                messageId)));
-    }
+		// Отправляем событие удаления через WebSocket
+		if (message.getRoom() != null) {
+			MessageResponse response = mapToMessageResponse(message, message.getRoom().getId());
+			response.setEventType(EventType.MESSAGE_DELETE);
+			messagingTemplate.convertAndSend("/topic/room." + message.getRoom().getId(), response);
+		} else if (message.getChannel() != null) {
+			ChannelMessageResponse response =
+					mapToChannelMessageResponse(message, message.getChannel());
+			response.setEventType(EventType.MESSAGE_DELETE);
+			messagingTemplate.convertAndSend("/topic/channel." + message.getChannel().getId(),
+					response);
+		}
+	}
 
-    public List<MessageResponse> getPrivateMessages(String currentUsername, Long userId) {
+
+	public Message getMessage(Long messageId) {
+		return messageRepository.findById(messageId)
+				.orElseThrow(() -> new MessageNotFoundException(String.format("%s (ID: %d)",
+						HttpResponseMessage.HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE.getMessage(),
+						messageId)));
+	}
+
+	public List<MessageResponse> getPrivateMessages(String currentUsername, Long userId) {
 		userService.getUser(userId);
-        Room privateRoom = roomService.getPrivateRoomIfExists(currentUsername, userId);
-        if (privateRoom == null) {
-            return new ArrayList<>();
-        }
-        
-        return messageRepository.findByRoomIdAndDeletedAtIsNullOrderBySentAtAsc(privateRoom.getId())
-                .stream()
-                .map(message -> mapToMessageResponse(message, privateRoom.getId()))
-                .toList();
-    }
+		Room privateRoom = roomService.getPrivateRoomIfExists(currentUsername, userId);
+		if (privateRoom == null) {
+			return new ArrayList<>();
+		}
 
-    // ===== PRIVATE HELPER METHODS =====
+		return messageRepository.findByRoomIdAndDeletedAtIsNullOrderBySentAtAsc(privateRoom.getId())
+				.stream().map(message -> mapToMessageResponse(message, privateRoom.getId()))
+				.toList();
+	}
 
-    private Message createMessage(User sender, String content, Room room, Channel channel) {
-        Message message = new Message();
-        message.setSender(sender);
-        message.setContent(content);
-        message.setType(MessageType.DEFAULT);
-        message.setRoom(room);
-        message.setChannel(channel);
-        message.setReplyToMessage(null);
-        message.setEditedAt(null);
-        message.setDeletedAt(null);
-        message.setSentAt(LocalDateTime.now());
-        return message;
-    }
+	public void sendErrorMessage(String username, String message, HttpStatus status) {
+		ChatErrorMessageResponse messageResponse = new ChatErrorMessageResponse();
+		messageResponse.setMessage(message);
+		messageResponse.setStatus(status.value());
+		messagingTemplate.convertAndSendToUser(username, "/queue/errors", messageResponse);
+	}
 
-    private MessageResponse mapToMessageResponse(Message message, Long roomId) {
-        MessageResponse response = new MessageResponse();
-        response.setId(message.getId());
-        response.setContent(message.getContent());
-        response.setSenderUsername(message.getSender().getUsername());
-        response.setSentAt(message.getSentAt());
-        response.setMessageType(message.getType());
-        response.setRoomId(roomId);
-        return response;
-    }
+	// ===== PRIVATE HELPER METHODS =====
 
-    private ChannelMessageResponse mapToChannelMessageResponse(Message message, Channel channel) {
-        ChannelMessageResponse response = new ChannelMessageResponse();
-        response.setId(message.getId());
-        response.setContent(message.getContent());
-        response.setSenderUsername(message.getSender().getUsername());
-        response.setSenderId(message.getSender().getId());
-        response.setSentAt(message.getSentAt());
-        response.setMessageType(message.getType());
-        response.setChannelId(channel.getId());
-        response.setChannelName(channel.getName());
-        response.setServerId(channel.getFolder().getServer().getId());
-        response.setIsEdited(message.isEdited());
-        if (message.getReplyToMessage() != null) {
-            response.setReplyToMessageId(message.getReplyToMessage().getId().toString());
-        }
-        return response;
-    }
+	private Message createMessage(User sender, String content, Room room, Channel channel) {
+		Message message = new Message();
+		message.setSender(sender);
+		message.setContent(content);
+		message.setType(MessageType.DEFAULT);
+		message.setRoom(room);
+		message.setChannel(channel);
+		message.setReplyToMessage(null);
+		message.setEditedAt(null);
+		message.setDeletedAt(null);
+		message.setSentAt(LocalDateTime.now());
+		return message;
+	}
+
+	private MessageResponse mapToMessageResponse(Message message, Long roomId) {
+		MessageResponse response = new MessageResponse();
+		response.setId(message.getId());
+		response.setContent(message.getContent());
+		response.setSenderUsername(message.getSender().getUsername());
+		response.setSentAt(message.getSentAt());
+		response.setMessageType(message.getType());
+		response.setRoomId(roomId);
+		return response;
+	}
+
+	private ChannelMessageResponse mapToChannelMessageResponse(Message message, Channel channel) {
+		ChannelMessageResponse response = new ChannelMessageResponse();
+		response.setId(message.getId());
+		response.setContent(message.getContent());
+		response.setSenderUsername(message.getSender().getUsername());
+		response.setSenderId(message.getSender().getId());
+		response.setSentAt(message.getSentAt());
+		response.setMessageType(message.getType());
+		response.setChannelId(channel.getId());
+		response.setChannelName(channel.getName());
+		response.setServerId(channel.getFolder().getServer().getId());
+		response.setIsEdited(message.isEdited());
+		if (message.getReplyToMessage() != null) {
+			response.setReplyToMessageId(message.getReplyToMessage().getId().toString());
+		}
+		return response;
+	}
 }

--- a/src/main/java/com/zvonok/service/WebSocketActiveSessionService.java
+++ b/src/main/java/com/zvonok/service/WebSocketActiveSessionService.java
@@ -1,0 +1,62 @@
+package com.zvonok.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WebSocketActiveSessionService {
+
+	private final Map<String, String> sessionIdToUser = new ConcurrentHashMap<>();
+	private final Map<String, Set<String>> userToSessions = new ConcurrentHashMap<>();
+
+	public void addSession(String username, String sessionId) {
+		userToSessions.compute(username, (k, sessions) -> {
+			if (sessions == null) {
+				Set<String> newSessions = ConcurrentHashMap.newKeySet();
+				newSessions.add(sessionId);
+				return newSessions;
+			}
+
+			sessions.add(sessionId);
+			return sessions;
+		});
+		sessionIdToUser.put(sessionId, username);
+	}
+
+	public void removeSession(String sessionId) {
+		String username = sessionIdToUser.remove(sessionId);
+		if (username == null) {
+			return;
+		}
+		userToSessions.computeIfPresent(username, (u, sessions) -> {
+			sessions.remove(sessionId);
+			return sessions.isEmpty() ? null : sessions;
+		});
+	}
+
+	public boolean isUserOnline(String username) {
+		Set<String> sessions = userToSessions.get(username);
+
+		return sessions != null && !sessions.isEmpty();
+	}
+
+	public Set<String> getOnlineUsers() {
+		return Set.copyOf(userToSessions.keySet());
+	}
+
+	public int getUserSessionCount(String username) {
+		Set<String> sessions = userToSessions.get(username);	
+		return sessions == null ? 0: sessions.size();
+	}
+
+	public Map<String, Integer> getOnlineUserSessionsCounts() {
+		Map<String, Integer> result = new HashMap<>();
+		for (Map.Entry<String, Set<String>> entry: userToSessions.entrySet()) {
+			result.put(entry.getKey(), entry.getValue().size());	
+		}
+		return result;
+	}
+}


### PR DESCRIPTION
## Description
Implement backend WebSocket error handling and graceful disconnect for STOMP connections.

## Changes
- Add `JwtHandshakeInterceptor` and `JwtHandshakeHandler` for JWT validation on WebSocket handshake and binding `UserPrincipal` to the session.
- Add `JwtChannelInterceptor` to validate `Principal` and JWT on incoming STOMP frames (except CONNECT/DISCONNECT).
- Add `WebSocketActiveSessionService` and `WebSocketEventListener` to track active STOMP sessions and clean them up on `SessionDisconnectEvent` (including timeouts and protocol errors).
- Add `@MessageExceptionHandler` in `ChatController` to map backend exceptions to `ChatErrorMessageResponse` and send them to `/user/queue/errors` without closing the WebSocket.
- Use existing business exceptions (`User not found`, `InsufficientPermissionsException`, etc.) to produce consistent `{message, status}` error DTOs for WebSocket clients.

> Client-side parts of the issue (StompFrameHandler, reconnection logic, failed message queue) are not included in this PR and will be implemented on the frontend side later.

closes #7 
