### PR TITLE
авторизация перешла на cookie систему

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ bin/
 **/application-dev.properties
 **/application-prod.properties
 **/application-*.properties
+**/application.yml
+**/application-*.yml
 !**/application.properties.example
 
 # OS files

--- a/src/main/java/com/zvonok/config/CookieProperties.java
+++ b/src/main/java/com/zvonok/config/CookieProperties.java
@@ -1,0 +1,16 @@
+package com.zvonok.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Component
+@ConfigurationProperties("security.cookie")
+@Data
+public class CookieProperties {
+	private String sameSite;
+	private boolean secure;
+	private long maxAge;
+	private String path;
+}

--- a/src/main/java/com/zvonok/controller/AuthController.java
+++ b/src/main/java/com/zvonok/controller/AuthController.java
@@ -6,89 +6,92 @@ import com.zvonok.service.dto.AuthResponse;
 import com.zvonok.service.dto.request.LoginRequest;
 import com.zvonok.service.dto.request.LogoutRequest;
 import com.zvonok.service.dto.request.RegisterRequest;
-import com.zvonok.service.dto.request.TokenRefreshRequest;
 import com.zvonok.service.dto.response.LogoutResponse;
 import com.zvonok.service.dto.response.MeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import com.zvonok.config.CookieProperties;
+import com.zvonok.controller.dto.LoginResponseDto;
 import com.zvonok.documentation.AuthApiDescriptions;
 import com.zvonok.documentation.annotation.ApiResponse400;
 import com.zvonok.documentation.annotation.ApiResponse409;
 import com.zvonok.documentation.annotation.SecuredApiResponses;
-import com.zvonok.exception.InvalidRefreshTokenException;
-import com.zvonok.exception_handler.enumeration.HttpResponseMessage;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
-@Tag(name = "Авторизационный контроллер",
-		description = "Контролер отвечающий за авторизацию пользователя и смежным функционалом")
+@Tag(name = "Авторизационный контроллер", description = "Контролер отвечающий за авторизацию пользователя и смежным функционалом")
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 	private final AuthService authService;
+	private final CookieProperties cookieProperties;
 
-	@Operation(summary = "Регистрирует пользователя",
-			description = "Создаёт пользователя в бд и далее автоматически авторизовывает его возвращаю стандартный авторизационный ответ")
-	@ApiResponse(responseCode = "200", description = AuthApiDescriptions.AUTH_REGISTER_SUCCESS)
+	@Operation(summary = "Регистрирует пользователя", description = "Создаёт пользователя в бд и далее автоматически авторизовывает его возвращаю стандартный авторизационный ответ")
+	@ApiResponse(responseCode = "201", description = AuthApiDescriptions.AUTH_REGISTER_SUCCESS)
 	@ApiResponse400
 	@ApiResponse409(description = AuthApiDescriptions.AUTH_USER_ALREADY_EXISTS)
 	@PostMapping("/register")
-	public AuthResponse register(@Valid @RequestBody RegisterRequest request) {
-		return authService.register(request.getUsername(), request.getEmail(),
+	public ResponseEntity<LoginResponseDto> register(@Valid @RequestBody RegisterRequest request) {
+		AuthResponse authData = authService.register(request.getUsername(), request.getEmail(),
 				request.getPassword());
+		return ResponseEntity.status(201)
+				.header("Set-Cookie", buildRefreshCookie(authData.getRefreshToken()).toString()).body(
+						buildLoginResponseDto(authData));
 	}
 
 	@Operation(summary = "Позволяет пользователю войти в систему")
 	@ApiResponse(responseCode = "200", description = "Успешный вход")
 	@ApiResponse400
 	@PostMapping("/login")
-	public AuthResponse login(@Valid @RequestBody LoginRequest request) {
-		return authService.login(request.getUsernameOrEmail(), request.getPassword());
+	public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequest request) {
+		AuthResponse authData = authService.login(request.getUsernameOrEmail(), request.getPassword());
+		return ResponseEntity.status(200)
+				.header("Set-Cookie", buildRefreshCookie(authData.getRefreshToken()).toString())
+				.body(buildLoginResponseDto(authData));
 	}
 
-	@Operation(summary = "Переавторизовывает пользователя по refresh токену",
-			description = "Переавторизовывает пользователя по refresh токену выдовая новые jwt и refresh токены и помечая использованный refresh токен как revoked (отменённый)")
+	@Operation(summary = "Переавторизовывает пользователя по refresh токену", description = "Переавторизовывает пользователя по refresh токену выдовая новые jwt и refresh токены и помечая использованный refresh токен как revoked (отменённый)")
 	@ApiResponse(responseCode = "200", description = AuthApiDescriptions.AUTH_REFRESH_SUCCESS)
 	@ApiResponse400
 	@PostMapping("/refresh")
-	public AuthResponse refresh(@Valid @RequestBody TokenRefreshRequest request) {
-		return authService.refresh(request.getRefreshToken());
+	public ResponseEntity<LoginResponseDto> refresh(@CookieValue(value = "refreshToken") String refreshCookie) {
+		AuthResponse authData = authService.refresh(refreshCookie);
+		return ResponseEntity.status(200)
+				.header("Set-Cookie", buildRefreshCookie(authData.getRefreshToken()).toString())
+				.body(buildLoginResponseDto(authData));
 	}
 
-	@Operation(summary = "Деавторизовывает пользователя по refresh токену",
-			description = "Произоводит деавторизацию пользователю по refresh токену методом отзывания refresh токена(ов)")
+	@Operation(summary = "Деавторизовывает пользователя по refresh токену", description = "Произоводит деавторизацию пользователю по refresh токену методом отзывания refresh токена(ов)")
 	@SecurityRequirement(name = "JWT")
 	@SecuredApiResponses
 	@ApiResponse(responseCode = "200", description = AuthApiDescriptions.AUTH_LOGOUT_SUCCESS)
 	@ApiResponse400
 	@PostMapping("/logout")
 	public ResponseEntity<LogoutResponse> logout(@Valid @RequestBody LogoutRequest request,
+			@CookieValue(value = "refreshToken") String refreshCookie,
 			@AuthenticationPrincipal UserPrincipal principal) {
 
-		if (!request.hasRefreshToken()) {
-			throw new InvalidRefreshTokenException(
-					HttpResponseMessage.HTTP_INVALID_REFRESH_TOKEN_RESPONSE_MESSAGE.getMessage());
-		}
-
 		if (request.isAllDevices()) {
-			authService.logoutFromAllDevices(request.getRefreshToken());
+			authService.logoutFromAllDevices(refreshCookie);
 		} else {
-			authService.logout(request.getRefreshToken());
+			authService.logout(refreshCookie);
 		}
 		LogoutResponse response = new LogoutResponse("Logout successful", request.isAllDevices());
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "Проверка идентификации по токену",
-			description = "Проверка jwt токена на валидность и возврат информации по токену")
+	@Operation(summary = "Проверка идентификации по токену", description = "Проверка jwt токена на валидность и возврат информации по токену")
 	@SecurityRequirement(name = "JWT")
 	@SecuredApiResponses
 	@ApiResponse(responseCode = "200", description = AuthApiDescriptions.AUTH_ME_SUCCESS)
@@ -104,5 +107,16 @@ public class AuthController {
 		response.setTime(LocalDateTime.now());
 
 		return ResponseEntity.ok(response);
+	}
+
+	private LoginResponseDto buildLoginResponseDto(AuthResponse authData) {
+		return new LoginResponseDto(authData.getAccessToken(), authData.getTokenType(), authData.getExpiresIn());
+	}
+
+	private ResponseCookie buildRefreshCookie(String refreshToken) {
+		return ResponseCookie.from("refreshToken", refreshToken).httpOnly(true)
+				.secure(cookieProperties.isSecure())
+				.path(cookieProperties.getPath()).sameSite(cookieProperties.getSameSite())
+				.maxAge(cookieProperties.getMaxAge()).build();
 	}
 }

--- a/src/main/java/com/zvonok/controller/dto/LoginResponseDto.java
+++ b/src/main/java/com/zvonok/controller/dto/LoginResponseDto.java
@@ -1,0 +1,25 @@
+package com.zvonok.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Schema(name = "LoginResponseDto",
+		description = "Ответ успешной аутентификации: access токен и параметры его использования.")
+public class LoginResponseDto {
+
+	@Schema(description = "JWT access token для авторизации запросов.",
+			example = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyMTYiLCJ1c2VySWQiO...",
+			accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.REQUIRED)
+	private String accessToken;
+
+	@Schema(description = "Тип токена для заголовка Authorization.", example = "Bearer",
+			accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.REQUIRED)
+	private String tokenType;
+
+	@Schema(description = "Время жизни access token в секундах.", example = "90000",
+			accessMode = Schema.AccessMode.READ_ONLY, requiredMode = Schema.RequiredMode.REQUIRED)
+	private long expiresIn;
+}

--- a/src/main/java/com/zvonok/exception_handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/zvonok/exception_handler/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.zvonok.exception_handler;
 
 import com.zvonok.exception.InvalidBooleanFormatException;
 import com.zvonok.exception_handler.annotation.ApiException;
+import com.zvonok.exception_handler.enumeration.HttpResponseMessage;
+
 import lombok.extern.slf4j.Slf4j;
 import org.reflections.Reflections;
 import org.springframework.http.HttpStatus;
@@ -9,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -20,8 +23,7 @@ import java.util.Set;
 @Slf4j
 public class GlobalExceptionHandler {
 
-	private final Map<Class<? extends RuntimeException>, HttpStatus> exceptionStatusMap =
-			new HashMap<>();
+	private final Map<Class<? extends RuntimeException>, HttpStatus> exceptionStatusMap = new HashMap<>();
 
 	public GlobalExceptionHandler() {
 		long startTime = System.currentTimeMillis();
@@ -71,8 +73,7 @@ public class GlobalExceptionHandler {
 
 		log.warn("❌ Validation error: {}", errorMessage);
 
-		JsonErrorResponse errorResponse =
-				new JsonErrorResponse(errorMessage, HttpStatus.BAD_REQUEST.value());
+		JsonErrorResponse errorResponse = new JsonErrorResponse(errorMessage, HttpStatus.BAD_REQUEST.value());
 
 		return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
 	}
@@ -82,8 +83,8 @@ public class GlobalExceptionHandler {
 			HttpMessageNotReadableException ex) {
 		Throwable rootCause = ex.getRootCause();
 		if (rootCause instanceof InvalidBooleanFormatException) {
-			JsonErrorResponse errorResponse =
-					new JsonErrorResponse(rootCause.getMessage(), HttpStatus.BAD_REQUEST.value());
+			JsonErrorResponse errorResponse = new JsonErrorResponse(rootCause.getMessage(),
+					HttpStatus.BAD_REQUEST.value());
 			return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
 		}
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -107,6 +108,12 @@ public class GlobalExceptionHandler {
 				.body(new JsonErrorResponse(message, HttpStatus.BAD_REQUEST.value()));
 	}
 
+	@ExceptionHandler(MissingRequestCookieException.class)
+	public ResponseEntity<JsonErrorResponse> handleMissingRequestCookieException(MissingRequestCookieException e) {
+		JsonErrorResponse errorResponse = new JsonErrorResponse(
+				HttpResponseMessage.HTTP_REFRESH_TOKEN_NOT_TRANSFERRED.getMessage(), HttpStatus.BAD_REQUEST.value());
+		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+	}
 
 	private String toHumanExpectedType(Class<?> requiredType) {
 		if (requiredType == null)

--- a/src/main/java/com/zvonok/exception_handler/enumeration/HttpResponseMessage.java
+++ b/src/main/java/com/zvonok/exception_handler/enumeration/HttpResponseMessage.java
@@ -4,25 +4,25 @@ import lombok.Getter;
 
 @Getter
 public enum HttpResponseMessage {
-    // Room
-    HTTP_ROOM_NOT_FOUND_RESPONSE_MESSAGE("Room was not found"),
+	// Room
+	HTTP_ROOM_NOT_FOUND_RESPONSE_MESSAGE("Room was not found"),
 	HTTP_INVALID_ROOM_SIZE_RESPONSE_MESSAGE("Invalid room size"),
-    HTTP_ROOM_SIZE_MAX_TEN_MEMBERS_RESPONSE_MESSAGE("Maximum of 10 members in group chat"),
+	HTTP_ROOM_SIZE_MAX_TEN_MEMBERS_RESPONSE_MESSAGE("Maximum of 10 members in group chat"),
 
-    // User
-    HTTP_USER_NOT_FOUND_RESPONSE_MESSAGE("User was not found"),
-    HTTP_USER_NOT_MEMBER_ROOM_RESPONSE_MESSAGE("User is not a member of the room"),
-    HTTP_USER_WITH_THIS_USERNAME_ALREADY_EXIST_RESPONSE_MESSAGE("User with this username already exist"),
-    HTTP_USER_WITH_THIS_EMAIL_ALREADY_EXIST_RESPONSE_MESSAGE("User with this email already exist"),
-    HTTP_OWNER_CAN_NOT_LEAVE_SERVER_RESPONSE_MESSAGE("The owner cannot leave the server. First pass the ownership."),
-    HTTP_YOU_NOT_MEMBER_THIS_SERVER_RESPONSE_MESSAGE("You are not a member of this server"),
+	// User
+	HTTP_USER_NOT_FOUND_RESPONSE_MESSAGE("User was not found"),
+	HTTP_USER_NOT_MEMBER_ROOM_RESPONSE_MESSAGE("User is not a member of the room"),
+	HTTP_USER_WITH_THIS_USERNAME_ALREADY_EXIST_RESPONSE_MESSAGE("User with this username already exist"),
+	HTTP_USER_WITH_THIS_EMAIL_ALREADY_EXIST_RESPONSE_MESSAGE("User with this email already exist"),
+	HTTP_OWNER_CAN_NOT_LEAVE_SERVER_RESPONSE_MESSAGE("The owner cannot leave the server. First pass the ownership."),
+	HTTP_YOU_NOT_MEMBER_THIS_SERVER_RESPONSE_MESSAGE("You are not a member of this server"),
 	HTTP_YOU_ALREADY_MEMBER_THIS_SERVER_RESPONSE_MESSAGE("You are already a member of this server"),
-    HTTP_FRIEND_REQUEST_NOT_FOUND_RESPONSE_MESSAGE("Friend request was not found"),
-    HTTP_FRIEND_REQUEST_ALREADY_EXISTS_RESPONSE_MESSAGE("Friend request already exists"),
-    HTTP_FRIEND_REQUEST_ACTION_NOT_ALLOWED_RESPONSE_MESSAGE("You cannot perform this action on the friend request"),
-    HTTP_CANNOT_ADD_SELF_AS_FRIEND_RESPONSE_MESSAGE("You cannot add yourself as a friend"),
-    HTTP_FRIENDSHIP_ALREADY_EXISTS_RESPONSE_MESSAGE("Users are already friends"),
-    HTTP_FRIENDSHIP_NOT_FOUND_RESPONSE_MESSAGE("Friendship was not found"),
+	HTTP_FRIEND_REQUEST_NOT_FOUND_RESPONSE_MESSAGE("Friend request was not found"),
+	HTTP_FRIEND_REQUEST_ALREADY_EXISTS_RESPONSE_MESSAGE("Friend request already exists"),
+	HTTP_FRIEND_REQUEST_ACTION_NOT_ALLOWED_RESPONSE_MESSAGE("You cannot perform this action on the friend request"),
+	HTTP_CANNOT_ADD_SELF_AS_FRIEND_RESPONSE_MESSAGE("You cannot add yourself as a friend"),
+	HTTP_FRIENDSHIP_ALREADY_EXISTS_RESPONSE_MESSAGE("Users are already friends"),
+	HTTP_FRIENDSHIP_NOT_FOUND_RESPONSE_MESSAGE("Friendship was not found"),
 	HTTP_INCORRECT_USER_USERNAME_LENGTH_RESPONSE_MESSAGE("Username must be between 3 and 50 characters"),
 	HTTP_INCORRECT_USER_EMAIL_LENGTH_RESPONSE_MESSAGE("Email must be between 5 and 100 characters"),
 	HTTP_INCORRECT_USER_PASSWORD_LENGTH_RESPONSE_MESSAGE("Password must be between 5 and 100 characters"),
@@ -30,48 +30,49 @@ public enum HttpResponseMessage {
 	HTTP_INCORRECT_USER_EMAIL_TYPE_RESPONSE_MESSAGE("Email can not be null"),
 	HTTP_INCORRECT_USER_PASSWORD_TYPE_RESPONSE_MESSAGE("Password can not be null"),
 	HTTP_USER_NOT_YOUR_FRIEND_RESPONSE_MESSAGE(" is not your friend"),
-    
-    // Channel
-    HTTP_CHANNEL_NOT_FOUND_RESPONSE_MESSAGE("Channel was not found"),
 
-    // Server
-    HTTP_SERVER_NOT_FOUND_RESPONSE_MESSAGE("Server was not found"),
-    HTTP_SERVER_NOT_ACTIVE_RESPONSE_MESSAGE("Server is not active now"),
-    HTTP_SERVER_NAME_NOT_VALID_RESPONSE_MESSAGE("Name must be between 5 and 100 characters"),
-    HTTP_SERVER_MAX_MEMBERS_NOT_VALID_RESPONSE_MESSAGE("MaxMembers must be between 10 and 10000 members"),
+	// Channel
+	HTTP_CHANNEL_NOT_FOUND_RESPONSE_MESSAGE("Channel was not found"),
 
-    // ServerRole
-    HTTP_SERVER_ROLE_NOT_FOUND_RESPONSE_MESSAGE("Role was not found"),
+	// Server
+	HTTP_SERVER_NOT_FOUND_RESPONSE_MESSAGE("Server was not found"),
+	HTTP_SERVER_NOT_ACTIVE_RESPONSE_MESSAGE("Server is not active now"),
+	HTTP_SERVER_NAME_NOT_VALID_RESPONSE_MESSAGE("Name must be between 5 and 100 characters"),
+	HTTP_SERVER_MAX_MEMBERS_NOT_VALID_RESPONSE_MESSAGE("MaxMembers must be between 10 and 10000 members"),
 
-    // ServerMemberRole
-    HTTP_SERVER_MEMBER_ROLE_NOT_FOUND_RESPONSE_MESSAGE("MemberRole was not found"),
+	// ServerRole
+	HTTP_SERVER_ROLE_NOT_FOUND_RESPONSE_MESSAGE("Role was not found"),
 
-    // ServerMember
-    HTTP_SERVER_MEMBER_NOT_FOUND_RESPONSE_MESSAGE("Member was not found"),
-    HTTP_SERVER_MAXIMUM_NUMBER_OF_SERVER_MEMBERS_RESPONSE_MESSAGE("Maximum number of members reached"),
-    HTTP_SERVER_BAN_NOT_FOUND_RESPONSE_MESSAGE("Ban record was not found"),
+	// ServerMemberRole
+	HTTP_SERVER_MEMBER_ROLE_NOT_FOUND_RESPONSE_MESSAGE("MemberRole was not found"),
+
+	// ServerMember
+	HTTP_SERVER_MEMBER_NOT_FOUND_RESPONSE_MESSAGE("Member was not found"),
+	HTTP_SERVER_MAXIMUM_NUMBER_OF_SERVER_MEMBERS_RESPONSE_MESSAGE("Maximum number of members reached"),
+	HTTP_SERVER_BAN_NOT_FOUND_RESPONSE_MESSAGE("Ban record was not found"),
 	HTTP_SERVER_MEMBER_ALREADY_WAS_KICKED_RESPONSE_MESSAGE("Member already kicked"),
 
-    // ChannelFolder
-    HTTP_CHANNEL_FOLDER_NOT_FOUND_RESPONSE_MESSAGE("Channel folder was not found"),
+	// ChannelFolder
+	HTTP_CHANNEL_FOLDER_NOT_FOUND_RESPONSE_MESSAGE("Channel folder was not found"),
 
-    // Permissions
-    HTTP_INSUFFICIENT_PERMISSIONS_RESPONSE_MESSAGE("Not enough rights to manage the server"),
-    HTTP_USER_BANNED_RESPONSE_MESSAGE("User is banned from this server"),
+	// Permissions
+	HTTP_INSUFFICIENT_PERMISSIONS_RESPONSE_MESSAGE("Not enough rights to manage the server"),
+	HTTP_USER_BANNED_RESPONSE_MESSAGE("User is banned from this server"),
 
-    // Authorization and validation data
-    HTTP_INVALID_JWT_RESPONSE_MESSAGE("JWT token not valid or missing!"),
-    HTTP_INVALID_USER_OR_PASSWORD_RESPONSE_MESSAGE("Invalid user or password"),
-    HTTP_INVALID_REFRESH_TOKEN_RESPONSE_MESSAGE("Refresh token is invalid"),
-    HTTP_REFRESH_TOKEN_EXPIRED_RESPONSE_MESSAGE("Refresh token has expired"),
-    HTTP_REFRESH_TOKEN_REVOKED_RESPONSE_MESSAGE("Refresh token is revoked"),
-    HTTP_REDEFINITION_RESPONSE_MESSAGE("Override can be either for the role or for the user"),
-    HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE("Message was not found"),
+	// Authorization and validation data
+	HTTP_INVALID_JWT_RESPONSE_MESSAGE("JWT token not valid or missing!"),
+	HTTP_INVALID_USER_OR_PASSWORD_RESPONSE_MESSAGE("Invalid user or password"),
+	HTTP_INVALID_REFRESH_TOKEN_RESPONSE_MESSAGE("Refresh token is invalid"),
+	HTTP_REFRESH_TOKEN_EXPIRED_RESPONSE_MESSAGE("Refresh token has expired"),
+	HTTP_REFRESH_TOKEN_REVOKED_RESPONSE_MESSAGE("Refresh token is revoked"),
+	HTTP_REFRESH_TOKEN_NOT_TRANSFERRED("Refresh token not transferred"),
+	HTTP_REDEFINITION_RESPONSE_MESSAGE("Override can be either for the role or for the user"),
+	HTTP_MESSAGE_NOT_FOUND_RESPONSE_MESSAGE("Message was not found"),
 	HTTP_AUTH_PRINCEPAL_REQUIRED_RESPONSE_MESSAGE("Authenticated principal required for this WebSocket operation");
 
-    private final String message;
+	private final String message;
 
-    HttpResponseMessage(String message) {
-        this.message = message;
-    }
+	HttpResponseMessage(String message) {
+		this.message = message;
+	}
 }

--- a/src/main/java/com/zvonok/service/dto/request/LogoutRequest.java
+++ b/src/main/java/com/zvonok/service/dto/request/LogoutRequest.java
@@ -3,9 +3,7 @@ package com.zvonok.service.dto.request;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.zvonok.utils.StrictBooleanDeserializer;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,13 +13,6 @@ import lombok.Setter;
 		description = "Запрос на выход из аккаунта (инвалидация refresh token).")
 public class LogoutRequest {
 
-	@Schema(description = "Refresh token. Обязателен, фиксированной длины 59 символов.",
-			example = "f8289b75-07ea-4cab-93bb-8c89f164dc15.zDrAPoYawtdRsAxf4ffkZw", minLength = 59,
-			maxLength = 59, nullable = false, requiredMode = Schema.RequiredMode.REQUIRED)
-	@NotBlank(message = "RefreshToken is required")
-	@Size(min = 59, max = 59, message = "RefreshToken must be 59 characters")
-	private String refreshToken;
-
 	@Schema(description = "Если true — выйти со всех устройств (инвалидировать все refresh токены пользователя). Если false — только текущую сессию.",
 			example = "false", defaultValue = "false", nullable = false,
 			requiredMode = Schema.RequiredMode.REQUIRED)
@@ -29,9 +20,5 @@ public class LogoutRequest {
 	@JsonDeserialize(using = StrictBooleanDeserializer.class)
 	private boolean allDevices = false;
 
-	@Schema(hidden = true)
-	public boolean hasRefreshToken() {
-		return refreshToken != null && !refreshToken.isBlank();
-	}
 }
 

--- a/src/test/java/com/zvonok/unittests/controller/AuthControllerTest.java
+++ b/src/test/java/com/zvonok/unittests/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.stream.Stream;
 
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import com.zvonok.config.CookieProperties;
 import com.zvonok.controller.AuthController;
 import com.zvonok.exception.InvalidRefreshTokenException;
 import com.zvonok.exception.InvalidUserOrPasswordException;
@@ -40,12 +43,9 @@ import com.zvonok.service.dto.AuthResponse;
 public class AuthControllerTest {
 
 	private static final String VALID_REFRESH_TOKEN = "valid-refresh-token" + "x".repeat(59 - 19);
-	private static final String INVALID_REFRESH_TOKEN =
-			"invalid-refresh-token" + "x".repeat(59 - 21);
-	private static final String REVOKED_REFRESH_TOKEN =
-			"revoked-refresh-token" + "x".repeat(59 - 21);
-	private static final String EXPIRED_REFRESH_TOKEN =
-			"expired-refresh-token" + "x".repeat(59 - 21);
+	private static final String INVALID_REFRESH_TOKEN = "invalid-refresh-token" + "x".repeat(59 - 21);
+	private static final String REVOKED_REFRESH_TOKEN = "revoked-refresh-token" + "x".repeat(59 - 21);
+	private static final String EXPIRED_REFRESH_TOKEN = "expired-refresh-token" + "x".repeat(59 - 21);
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -56,12 +56,17 @@ public class AuthControllerTest {
 	@MockitoBean
 	JwtTokenProvider jwtTokenProvider;
 
+	@MockitoBean
+	private CookieProperties cookieProperties;
 	private AuthResponse authResponse;
 
 	@BeforeEach
 	void setUp() {
-		authResponse =
-				new AuthResponse("test-access-token", "test-refresh-token", "Bearer", 3600000L);
+		authResponse = new AuthResponse("test-access-token", "test-refresh-token", "Bearer", 3600000L);
+		when(cookieProperties.isSecure()).thenReturn(false);
+		when(cookieProperties.getPath()).thenReturn("/auth/refresh");
+		when(cookieProperties.getSameSite()).thenReturn("Lax");
+		when(cookieProperties.getMaxAge()).thenReturn(1209600L);
 
 	}
 
@@ -86,9 +91,8 @@ public class AuthControllerTest {
 		mockMvc.perform(post("/auth/register").contentType(MediaType.APPLICATION_JSON)
 				.content(registerRequestJson("testUser", "testEmail@example.ru", "qwerty123")))
 				// Assert
-				.andExpect(status().isOk())
+				.andExpect(status().isCreated())
 				.andExpectAll(jsonPath("$.accessToken").value("test-access-token"),
-						jsonPath("$.refreshToken").value("test-refresh-token"),
 						jsonPath("$.tokenType").value("Bearer"));
 	}
 
@@ -146,7 +150,6 @@ public class AuthControllerTest {
 				// Assert
 				.andExpect(status().isOk())
 				.andExpectAll(jsonPath("$.accessToken").value("test-access-token"),
-						jsonPath("$.refreshToken").value("test-refresh-token"),
 						jsonPath("$.tokenType").value("Bearer"));
 	}
 
@@ -171,15 +174,6 @@ public class AuthControllerTest {
 	}
 
 	// Refresh
-	static String refreshRequestJson(String refreshToken) {
-		return """
-				    {
-				        "refreshToken": "%s"
-				    }
-				""".formatted(refreshToken);
-	}
-
-
 	@Test
 	@DisplayName("refresh - успешное обновление токена")
 	void refresh_shouldReturn200_whenValidRequest() throws Exception {
@@ -188,11 +182,10 @@ public class AuthControllerTest {
 
 		// Act
 		mockMvc.perform(post("/auth/refresh").contentType(MediaType.APPLICATION_JSON)
-				.content(refreshRequestJson(VALID_REFRESH_TOKEN)))
+				.cookie(new Cookie("refreshToken", VALID_REFRESH_TOKEN)))
 				// Assert
 				.andExpect(status().isOk())
 				.andExpectAll(jsonPath("$.accessToken").value("test-access-token"),
-						jsonPath("$.refreshToken").value("test-refresh-token"),
 						jsonPath("$.tokenType").value("Bearer"));
 	}
 
@@ -200,19 +193,19 @@ public class AuthControllerTest {
 	@DisplayName("refresh - должен выбросить исключение при невалидном токене")
 	@MethodSource("refreshExceptionCases")
 	void refresh_shouldThrowException(RuntimeException exception, String exceptionMessage,
-			String content) throws Exception {
+			String refreshToken) throws Exception {
 		// Arrange
 		when(authService.refresh(anyString())).thenThrow(exception);
 
 		// Act
 		mockMvc.perform(
-				post("/auth/refresh").contentType(MediaType.APPLICATION_JSON).content(content))
+				post("/auth/refresh").contentType(MediaType.APPLICATION_JSON)
+						.cookie(new Cookie("refreshToken", refreshToken)))
 				// Assert
 				.andExpect(status().isUnauthorized())
 				.andExpectAll(jsonPath("$.message").value(exceptionMessage),
 						jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()));
 	}
-
 
 	static private Stream<Arguments> refreshExceptionCases() {
 		return Stream.of(
@@ -222,31 +215,30 @@ public class AuthControllerTest {
 										.getMessage()),
 						HttpResponseMessage.HTTP_INVALID_REFRESH_TOKEN_RESPONSE_MESSAGE
 								.getMessage(),
-						refreshRequestJson(INVALID_REFRESH_TOKEN)),
+						INVALID_REFRESH_TOKEN),
 				Arguments.of(
 						new RefreshTokenRevokedException(
 								HttpResponseMessage.HTTP_REFRESH_TOKEN_REVOKED_RESPONSE_MESSAGE
 										.getMessage()),
 						HttpResponseMessage.HTTP_REFRESH_TOKEN_REVOKED_RESPONSE_MESSAGE
 								.getMessage(),
-						refreshRequestJson(REVOKED_REFRESH_TOKEN)),
+						REVOKED_REFRESH_TOKEN),
 				Arguments.of(
 						new RefreshTokenExpiredException(
 								HttpResponseMessage.HTTP_REFRESH_TOKEN_EXPIRED_RESPONSE_MESSAGE
 										.getMessage()),
 						HttpResponseMessage.HTTP_REFRESH_TOKEN_EXPIRED_RESPONSE_MESSAGE
 								.getMessage(),
-						refreshRequestJson(EXPIRED_REFRESH_TOKEN)));
+						EXPIRED_REFRESH_TOKEN));
 	}
 
 	// Logout
-	static String logoutRequestJson(String refreshToken, boolean allDevices) {
+	static String logoutRequestJson(boolean allDevices) {
 		return """
 				    {
-				        "refreshToken": "%s",
 				        "allDevices": %b
 				    }
-				""".formatted(refreshToken, allDevices);
+				""".formatted(allDevices);
 	}
 
 	@Test
@@ -256,7 +248,8 @@ public class AuthControllerTest {
 
 		// Act
 		mockMvc.perform(post("/auth/logout").contentType(MediaType.APPLICATION_JSON)
-				.content(logoutRequestJson(VALID_REFRESH_TOKEN, false)))
+				.content(logoutRequestJson(false))
+				.cookie(new Cookie("refreshToken", VALID_REFRESH_TOKEN)))
 				// Assert
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.message").value("Logout successful"))
@@ -273,7 +266,8 @@ public class AuthControllerTest {
 
 		// Act
 		mockMvc.perform(post("/auth/logout").contentType(MediaType.APPLICATION_JSON)
-				.content(logoutRequestJson(VALID_REFRESH_TOKEN, true)))
+				.content(logoutRequestJson(true))
+				.cookie(new Cookie("refreshToken", VALID_REFRESH_TOKEN)))
 				// Assert
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.message").value("Logout successful"))
@@ -281,32 +275,6 @@ public class AuthControllerTest {
 
 		verify(authService).logoutFromAllDevices(VALID_REFRESH_TOKEN);
 		verify(authService, never()).logout(anyString());
-	}
-
-	@ParameterizedTest
-	@DisplayName("logout - должен выбросить исключение при неверной длине токена")
-	@MethodSource("logoutInvalidRefreshTokenExceptionCases")
-	void logout_shouldThrowException_whenInvalidRefreshTokenLength(String exceptionMessage,
-			String content) throws Exception {
-		// Arrange
-
-		// Act
-		mockMvc.perform(
-				post("/auth/logout").contentType(MediaType.APPLICATION_JSON).content(content))
-				// Assert
-				.andExpect(status().isBadRequest())
-				.andExpectAll(jsonPath("$.message").value(exceptionMessage),
-						jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
-	}
-
-	static Stream<Arguments> logoutInvalidRefreshTokenExceptionCases() {
-		final String refreshTokenLengthMessage = "refreshToken: RefreshToken must be 59 characters";
-		return Stream.of(
-				// Refresh token length check
-				Arguments.of(refreshTokenLengthMessage,
-						logoutRequestJson("invalidRefreshToken", false)),
-				Arguments.of(refreshTokenLengthMessage,
-						logoutRequestJson("invalidRefreshToken", true)));
 	}
 
 	@ParameterizedTest
@@ -319,7 +287,8 @@ public class AuthControllerTest {
 		doThrow(exception).when(authService).logoutFromAllDevices(refreshToken);
 		// Act
 		mockMvc.perform(
-				post("/auth/logout").contentType(MediaType.APPLICATION_JSON).content(content))
+				post("/auth/logout").contentType(MediaType.APPLICATION_JSON).content(content)
+						.cookie(new Cookie("refreshToken", refreshToken)))
 				// Assert
 				.andExpect(status().isUnauthorized())
 				.andExpectAll(jsonPath("$.message").value(exceptionMessage),
@@ -334,25 +303,25 @@ public class AuthControllerTest {
 						new InvalidRefreshTokenException(
 								HttpResponseMessage.HTTP_INVALID_REFRESH_TOKEN_RESPONSE_MESSAGE
 										.getMessage()),
-						invalidRefreshTokenMessage, logoutRequestJson(INVALID_REFRESH_TOKEN, false),
+						invalidRefreshTokenMessage, logoutRequestJson(false),
 						INVALID_REFRESH_TOKEN),
 				Arguments.of(
 						new InvalidRefreshTokenException(
 								HttpResponseMessage.HTTP_INVALID_REFRESH_TOKEN_RESPONSE_MESSAGE
 										.getMessage()),
-						invalidRefreshTokenMessage, logoutRequestJson(INVALID_REFRESH_TOKEN, true),
+						invalidRefreshTokenMessage, logoutRequestJson(true),
 						INVALID_REFRESH_TOKEN),
 				Arguments.of(
 						new RefreshTokenRevokedException(
 								HttpResponseMessage.HTTP_REFRESH_TOKEN_REVOKED_RESPONSE_MESSAGE
 										.getMessage()),
-						revokedRefreshTokenMessage, logoutRequestJson(REVOKED_REFRESH_TOKEN, false),
+						revokedRefreshTokenMessage, logoutRequestJson(false),
 						REVOKED_REFRESH_TOKEN),
 				Arguments.of(
 						new RefreshTokenRevokedException(
 								HttpResponseMessage.HTTP_REFRESH_TOKEN_REVOKED_RESPONSE_MESSAGE
 										.getMessage()),
-						revokedRefreshTokenMessage, logoutRequestJson(REVOKED_REFRESH_TOKEN, true),
+						revokedRefreshTokenMessage, logoutRequestJson(true),
 						REVOKED_REFRESH_TOKEN));
 	}
 }


### PR DESCRIPTION
## Description
Move refresh token from JSON body to HttpOnly cookie and unify auth responses.

## Changes
- Added `CookieProperties` with profile-based configuration for refresh token cookie (SameSite, Secure, Path, Max-Age).
- Updated `AuthController`:
  - `register`, `login`, `refresh` now set refresh token in HttpOnly cookie using a shared `buildRefreshCookie` helper.
  - All three endpoints return `LoginResponseDto` in the response body with access token data only.
  - `refresh` and `logout` now read the refresh token from the `refreshToken` cookie via `@CookieValue`.
- Extended global exception handling:
  - Added handler for `MissingRequestCookieException` returning `400 Bad Request` with `HTTP_REFRESH_TOKEN_NOT_TRANSFERRED` message.
  - Kept existing 401 responses for invalid, expired or revoked refresh tokens.
- Adjusted dev/prod configuration for cookie security settings in `application-dev.yml` and `application-prod.yml`.

closes #29
