### PR TITLE
Add single-level message reply support (replyToMessageId + compact preview)

### DIFF
--- a/docs/message-replies-backend-notes.md
+++ b/docs/message-replies-backend-notes.md
@@ -1,0 +1,88 @@
+# Message replies backend notes
+
+## 1) Модули и файлы reply support
+- `Message` entity хранит `replyToMessageId` как nullable-ссылку на parent message (single-level).  
+- WS create-flow для DM/room/channel идёт через `ChatController` -> `MessageService`.  
+- История room/private и realtime payload room/DM собираются в `MessageService`.  
+- История channel payload собирается в `ChannelService`; realtime channel payload в `MessageService`.
+
+Ключевые файлы:
+- `src/main/java/com/zvonok/model/Message.java`
+- `src/main/java/com/zvonok/controller/ChatController.java`
+- `src/main/java/com/zvonok/service/MessageService.java`
+- `src/main/java/com/zvonok/service/ChannelService.java`
+- `src/main/java/com/zvonok/controller/dto/ShortMessageWrapped.java`
+- `src/main/java/com/zvonok/controller/dto/ChannelMessageResponse.java`
+- `src/main/java/com/zvonok/controller/dto/MessageResponse.java`
+- `src/main/java/com/zvonok/controller/dto/ReplyPreviewDto.java`
+- `src/main/java/com/zvonok/controller/dto/WebSocketMessageRequest.java`
+
+## 2) Как reply metadata проходит по flow
+
+### Create flow (WebSocket)
+1. Клиент шлёт payload в `/app/chat/private/{receiverUsername}`, `/app/chat/send/{roomId}` или `/app/chat/channel/{channelId}`.
+2. `ChatController` поддерживает backward compatibility:
+   - старый формат: plain string (без reply);
+   - новый формат: object с `content` + `replyToMessageId` (или `parentMessageId` как alias).
+3. `MessageService` валидирует parent:
+   - parent существует;
+   - parent не deleted;
+   - parent в том же room/channel context.
+4. Сообщение сохраняется с `replyToMessageId`.
+5. В outgoing DTO добавляются:
+   - `replyToMessageId`;
+   - `replyPreview` (один уровень, compact).
+
+### Fetch flow (REST history)
+- Room history (`/rooms/{roomId}/messages`) и private history (`/rooms/private/{userId}/messages`) получают reply metadata через `MessageService`.
+- Channel history (`.../channels/{channelId}/messages`) получает reply metadata через `ChannelService`.
+- Для page/history используется batch-load parent сообщений (`findAllById`) для снижения N+1.
+
+### WebSocket realtime flow
+- `MESSAGE`, `MESSAGE_EDIT`, `MESSAGE_DELETE` для room/DM и channel сохраняют существующие event names/types.
+- В payload добавляется `replyToMessageId` + `replyPreview`.
+- Контракт не строит recursive parent/children tree.
+
+## 3) Где хранится parentMessageId / replyToMessageId
+- Хранится в `message.reply_to_message_id` через поле `Message.replyToMessageId` (nullable).
+- Для старых сообщений значение `null` и они остаются валидными.
+
+## 4) Ограничения текущей реализации
+- Только single-level reference (одна ссылка на parent).
+- Нет thread/discussion model.
+- Preview parent возвращается компактно; полное родительское сообщение не сериализуется.
+- При hard-missing parent (если запись недоступна) возвращается fallback preview c `deleted=true`.
+
+## 5) Что безопасно менять / что рискованно
+
+### Безопасно
+- Добавлять поля внутрь `replyPreview` (backward-compatible, если nullable).
+- Менять правила обрезки snippet (например, длину) без изменения event names.
+
+### Рискованно
+- Менять существующие event names (`MESSAGE`, `MESSAGE_EDIT`, `MESSAGE_DELETE`).
+- Ломать dual-format WS input (string + object), так как это важно для backward compatibility.
+- Добавлять eager/self-referential загрузку parent как entity relationship без контроля, можно получить лишнюю нагрузку.
+
+## 6) Известные edge cases
+- Обычное сообщение (без reply): `replyToMessageId = null`, `replyPreview = null`.
+- Reply на reply: разрешён как обычная ссылка на одно parent сообщение.
+- Reply на deleted parent: запрещён на момент создания.
+- Parent удалён после создания replies: reply остаётся, preview показывает deleted state.
+- Parent из другого room/channel: валидация возвращает `400`.
+- Parent не существует: `404` (`MessageNotFoundException`).
+
+## 7) Ручная проверка reply feature
+1. Отправить обычное сообщение через WS string payload — должно работать как раньше.
+2. Отправить reply через WS object payload с `replyToMessageId` в том же room/channel.
+3. Получить history room/channel и проверить наличие `replyToMessageId` + `replyPreview`.
+4. Попробовать reply на message из другого context — получить validation error.
+5. Удалить parent message, затем:
+   - убедиться, что reply не удалился;
+   - убедиться, что preview у reply в deleted state.
+6. Отредактировать parent и проверить, что его собственный `MESSAGE_EDIT` приходит корректно.
+
+## 8) Assumptions / open questions
+- **Assumption:** для создания сообщений приоритетно используется WebSocket flow (`ChatController`), REST create endpoint не используется.
+- **Assumption:** `replyToMessageId` как naming уже принят в части контракта (channel DTO), поэтому оставлен как основной backend-field.
+- **Open question:** нужен ли отдельный broadcast/update для уже существующих reply-сообщений при edit parent (сейчас обновление выполняется через стандартный edit event parent).

--- a/src/main/java/com/zvonok/controller/ChatController.java
+++ b/src/main/java/com/zvonok/controller/ChatController.java
@@ -1,12 +1,12 @@
 package com.zvonok.controller;
 
-import com.zvonok.controller.dto.ChannelMessageResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.zvonok.controller.dto.WebSocketMessageRequest;
 import com.zvonok.exception.AuthenticatedPrincipalRequiredException;
 import com.zvonok.exception_handler.annotation.ApiException;
 import com.zvonok.exception_handler.enumeration.BusinessRuleMessage;
 import com.zvonok.service.MessageReadStatusService;
 import com.zvonok.service.MessageService;
-import com.zvonok.service.dto.MessageReadStatusContent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,7 +16,6 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
@@ -32,29 +31,35 @@ public class ChatController {
 
 	@MessageMapping("/private/{receiverUsername}")
 	public void sendPrivateMessage(@DestinationVariable String receiverUsername,
-			Principal principal, @Payload String content) {
+			Principal principal, @Payload JsonNode payload) {
 		String sender = resolvePrincipalName(principal);
-		validateContent(content);
+		WebSocketMessageRequest request = parseMessageRequest(payload);
+		validateContent(request.getContent());
 
-		messageService.sendPrivateMessage(sender, receiverUsername, content);
+		messageService.sendPrivateMessage(sender, receiverUsername, request.getContent(),
+				request.getReplyToMessageId());
 	}
 
 	@MessageMapping("/send/{roomId}")
 	public void sendMessage(@DestinationVariable Long roomId, Principal principal,
-			@Payload String content) {
+			@Payload JsonNode payload) {
 		String sender = resolvePrincipalName(principal);
-		validateContent(content);
+		WebSocketMessageRequest request = parseMessageRequest(payload);
+		validateContent(request.getContent());
 
-		messageService.sendMessage(sender, roomId, content);
+		messageService.sendMessage(sender, roomId, request.getContent(),
+				request.getReplyToMessageId());
 	}
 
 	@MessageMapping("/channel/{channelId}")
 	public void sendChannelMessage(@DestinationVariable Long channelId, Principal principal,
-			@Payload String content) {
+			@Payload JsonNode payload) {
 		String sender = resolvePrincipalName(principal);
-		validateContent(content);
+		WebSocketMessageRequest request = parseMessageRequest(payload);
+		validateContent(request.getContent());
 
-		messageService.sendChannelMessage(sender, channelId, content);
+		messageService.sendChannelMessage(sender, channelId, request.getContent(),
+				request.getReplyToMessageId());
 	}
 
 	@MessageMapping("/edit/{messageId}")
@@ -105,5 +110,51 @@ public class ChatController {
 		if (content == null || content.trim().isEmpty()) {
 			throw new IllegalArgumentException("Message content must not be empty");
 		}
+	}
+
+	private WebSocketMessageRequest parseMessageRequest(JsonNode payload) {
+		if (payload == null || payload.isNull()) {
+			return new WebSocketMessageRequest(null, null);
+		}
+
+		if (payload.isTextual()) {
+			return new WebSocketMessageRequest(payload.asText(), null);
+		}
+
+		String content = payload.has("content") && !payload.get("content").isNull()
+				? payload.get("content").asText()
+				: null;
+
+		Long replyToMessageId = extractNullableLong(payload, "replyToMessageId");
+		if (replyToMessageId == null) {
+			replyToMessageId = extractNullableLong(payload, "parentMessageId");
+		}
+
+		return new WebSocketMessageRequest(content, replyToMessageId);
+	}
+
+	private Long extractNullableLong(JsonNode payload, String fieldName) {
+		if (!payload.has(fieldName) || payload.get(fieldName).isNull()) {
+			return null;
+		}
+
+		JsonNode node = payload.get(fieldName);
+		if (node.isNumber()) {
+			return node.longValue();
+		}
+
+		if (node.isTextual()) {
+			String raw = node.asText().trim();
+			if (raw.isEmpty()) {
+				return null;
+			}
+			try {
+				return Long.parseLong(raw);
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException(fieldName + " must be a valid number");
+			}
+		}
+
+		throw new IllegalArgumentException(fieldName + " must be a valid number");
 	}
 }

--- a/src/main/java/com/zvonok/controller/dto/ChannelMessageResponse.java
+++ b/src/main/java/com/zvonok/controller/dto/ChannelMessageResponse.java
@@ -16,5 +16,6 @@ public class ChannelMessageResponse {
     private Long channelId;
     private EventType eventType;
     private Long replyToMessageId;
+	private ReplyPreviewDto replyPreview;
 	private LocalDateTime editedAt;
 }

--- a/src/main/java/com/zvonok/controller/dto/MessageResponse.java
+++ b/src/main/java/com/zvonok/controller/dto/MessageResponse.java
@@ -38,4 +38,12 @@ public class MessageResponse {
 	@Schema(description = "Тип события (если сообщение системное/событийное).",
 			example = "MESSAGE_CREATED", accessMode = Schema.AccessMode.READ_ONLY)
 	private EventType eventType;
+
+	@Schema(description = "ID родительского сообщения для reply (если есть).", example = "321",
+			accessMode = Schema.AccessMode.READ_ONLY)
+	private Long replyToMessageId;
+
+	@Schema(description = "Компактный preview родительского сообщения для reply.",
+			accessMode = Schema.AccessMode.READ_ONLY)
+	private ReplyPreviewDto replyPreview;
 }

--- a/src/main/java/com/zvonok/controller/dto/ReplyPreviewDto.java
+++ b/src/main/java/com/zvonok/controller/dto/ReplyPreviewDto.java
@@ -1,0 +1,18 @@
+package com.zvonok.controller.dto;
+
+import com.zvonok.model.enumeration.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ReplyPreviewDto {
+
+	private final Long id;
+	private final Long authorId;
+	private final String authorUsername;
+	private final String authorDisplayName;
+	private final String snippet;
+	private final MessageType type;
+	private final boolean deleted;
+}

--- a/src/main/java/com/zvonok/controller/dto/ShortMessageWrapped.java
+++ b/src/main/java/com/zvonok/controller/dto/ShortMessageWrapped.java
@@ -17,4 +17,6 @@ public class ShortMessageWrapped {
 	private final SenderDto sender;
 	private final RoomShortDto room;
 	private final LocalDateTime editedAt;
+	private final Long replyToMessageId;
+	private final ReplyPreviewDto replyPreview;
 }

--- a/src/main/java/com/zvonok/controller/dto/WebSocketMessageRequest.java
+++ b/src/main/java/com/zvonok/controller/dto/WebSocketMessageRequest.java
@@ -1,0 +1,11 @@
+package com.zvonok.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class WebSocketMessageRequest {
+	private final String content;
+	private final Long replyToMessageId;
+}

--- a/src/main/java/com/zvonok/service/ChannelService.java
+++ b/src/main/java/com/zvonok/service/ChannelService.java
@@ -1,6 +1,7 @@
 package com.zvonok.service;
 
 import com.zvonok.controller.dto.ChannelMessageResponse;
+import com.zvonok.controller.dto.ReplyPreviewDto;
 import com.zvonok.controller.dto.SenderDto;
 import com.zvonok.exception.ChannelNotFoundException;
 import com.zvonok.exception.InsufficientPermissionsException;
@@ -21,7 +22,11 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -144,11 +149,17 @@ public class ChannelService {
 					channelId, beforeMessageId, pageRequest);
 		}
 
+		Map<Long, ReplyPreviewDto> replyPreviewByParentId =
+				buildReplyPreviewByParentId(page.getContent());
+
 		return page.getContent().stream().sorted(Comparator.comparing(Message::getId))
-				.map(message -> mapToChannelMessageResponse(message, channel)).toList();
+				.map(message -> mapToChannelMessageResponse(message, channel,
+						replyPreviewByParentId.get(message.getReplyToMessageId())))
+				.toList();
 	}
 
-	private ChannelMessageResponse mapToChannelMessageResponse(Message message, Channel channel) {
+	private ChannelMessageResponse mapToChannelMessageResponse(Message message, Channel channel,
+			ReplyPreviewDto replyPreview) {
 		SenderDto sender = new SenderDto(message.getSender().getId(),
 				message.getSender().getUsername(), message.getSender().getDisplayName(),
 				message.getSender().getAvatarUrl(), message.getSender().getStatus());
@@ -162,9 +173,60 @@ public class ChannelService {
 		response.setChannelId(channel.getId());
 		response.setEventType(EventType.MESSAGE);
 		response.setReplyToMessageId(message.getReplyToMessageId());
+		response.setReplyPreview(replyPreview);
 		response.setEditedAt(message.getEditedAt());
 		return response;
 	}
-}
 
+	private Map<Long, ReplyPreviewDto> buildReplyPreviewByParentId(List<Message> messages) {
+		Set<Long> replyToIds = new HashSet<>();
+		for (Message message : messages) {
+			if (message.getReplyToMessageId() != null) {
+				replyToIds.add(message.getReplyToMessageId());
+			}
+		}
+
+		if (replyToIds.isEmpty()) {
+			return Map.of();
+		}
+
+		Map<Long, Message> parentById = new HashMap<>();
+		for (Message parent : messageRepository.findAllById(replyToIds)) {
+			parentById.put(parent.getId(), parent);
+		}
+
+		Map<Long, ReplyPreviewDto> previewByParentId = new HashMap<>();
+		for (Long replyToId : replyToIds) {
+			Message parent = parentById.get(replyToId);
+			if (parent == null) {
+				previewByParentId.put(replyToId,
+						new ReplyPreviewDto(replyToId, null, null, null, null, null, true));
+				continue;
+			}
+
+			boolean deleted = parent.isDeleted();
+			String snippet = deleted ? null : buildSnippet(parent.getContent());
+			previewByParentId.put(replyToId,
+					new ReplyPreviewDto(parent.getId(), parent.getSender().getId(),
+							parent.getSender().getUsername(), parent.getSender().getDisplayName(),
+							snippet, parent.getType(), deleted));
+		}
+
+		return previewByParentId;
+	}
+
+	private String buildSnippet(String content) {
+		if (content == null) {
+			return null;
+		}
+
+		String trimmed = content.trim();
+		int maxLength = 120;
+		if (trimmed.length() <= maxLength) {
+			return trimmed;
+		}
+
+		return trimmed.substring(0, maxLength) + "...";
+	}
+}
 

--- a/src/main/java/com/zvonok/service/MessageService.java
+++ b/src/main/java/com/zvonok/service/MessageService.java
@@ -2,10 +2,12 @@ package com.zvonok.service;
 
 import com.zvonok.controller.dto.ChannelMessageResponse;
 import com.zvonok.controller.dto.ChatErrorMessageResponse;
+import com.zvonok.controller.dto.ReplyPreviewDto;
 import com.zvonok.exception.CannotEditDeletedMessageException;
 import com.zvonok.exception.ChannelNotFoundException;
 import com.zvonok.exception.InsufficientPermissionsException;
 import com.zvonok.exception.MessageNotFoundException;
+import com.zvonok.exception.MessageTargetValidationException;
 import com.zvonok.exception.RoomNotFoundException;
 import com.zvonok.exception.UserNotFoundException;
 import com.zvonok.exception.UserNotMemberRoomException;
@@ -34,8 +36,12 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Service for managing messages in private rooms, group rooms, and channels. Сервис для управления
@@ -55,7 +61,7 @@ public class MessageService {
 
 
 	public ShortMessageWrapped sendPrivateMessage(String senderUsername, String receiverUsername,
-			String content) {
+			String content, Long replyToMessageId) {
 
 		Long durationStart = System.currentTimeMillis();
 		Message message = null;
@@ -75,7 +81,9 @@ public class MessageService {
 								.getMessage());
 			}
 
-			message = createMessage(sender, content, privateRoom, null);
+			validateReplyTarget(replyToMessageId, privateRoom, null);
+
+			message = createMessage(sender, content, privateRoom, null, replyToMessageId);
 			Message savedMessage = messageRepository.save(message);
 
 			// MessageResponse response = mapToMessageResponse(savedMessage,
@@ -107,7 +115,8 @@ public class MessageService {
 
 	}
 
-	public ShortMessageWrapped sendMessage(String senderUsername, long roomId, String content) {
+	public ShortMessageWrapped sendMessage(String senderUsername, long roomId, String content,
+			Long replyToMessageId) {
 		long durationStart = System.currentTimeMillis();
 		Message message = null;
 
@@ -124,7 +133,9 @@ public class MessageService {
 								.getMessage());
 			}
 
-			message = createMessage(sender, content, room, null);
+			validateReplyTarget(replyToMessageId, room, null);
+
+			message = createMessage(sender, content, room, null, replyToMessageId);
 			Message savedMessage = messageRepository.save(message);
 
 			// MessageResponse response = mapToMessageResponse(savedMessage, room.getId());
@@ -158,7 +169,7 @@ public class MessageService {
 	}
 
 	public ChannelMessageResponse sendChannelMessage(String senderUsername, Long channelId,
-			String content) {
+			String content, Long replyToMessageId) {
 		long durationStart = System.currentTimeMillis();
 		Message message = null;
 
@@ -172,7 +183,9 @@ public class MessageService {
 								.getMessage());
 			}
 
-			message = createMessage(sender, content, null, channel);
+			validateReplyTarget(replyToMessageId, null, channel);
+
+			message = createMessage(sender, content, null, channel, replyToMessageId);
 			Message savedMessage = messageRepository.save(message);
 
 			ChannelMessageResponse response =
@@ -302,22 +315,23 @@ public class MessageService {
 			}
 
 
+			message.setDeletedAt(LocalDateTime.now());
 			messageRepository.save(message);
 
-			List<ShortMessageWrapped> RoomMessages =
-					getRoomMessages(username, message.getRoom().getId(), null, 1);
+			if (message.getRoom() != null) {
+				List<ShortMessageWrapped> RoomMessages =
+						getRoomMessages(username, message.getRoom().getId(), null, 1);
 
+				ShortMessageWrapped lastRoomMessage =
+						RoomMessages.size() == 1 ? RoomMessages.getFirst() : null;
 
-			ShortMessageWrapped lastRoomMessage =
-					RoomMessages.size() == 1 ? RoomMessages.getFirst() : null;
-
-
-			if (lastRoomMessage != null) {
-				roomService.updateRoom(message.getRoom().getId(), username, null,
-						lastRoomMessage.getId(), lastRoomMessage.getContent(),
-						lastRoomMessage.getSentAt());
-			} else {
-				roomService.updateRoom(message.getRoom().getId(), username, null, null, null);
+				if (lastRoomMessage != null) {
+					roomService.updateRoom(message.getRoom().getId(), username, null,
+							lastRoomMessage.getId(), lastRoomMessage.getContent(),
+							lastRoomMessage.getSentAt());
+				} else {
+					roomService.updateRoom(message.getRoom().getId(), username, null, null, null);
+				}
 			}
 
 			// Отправляем событие удаления через WebSocket
@@ -377,8 +391,13 @@ public class MessageService {
 					roomId, beforeMessage.getId(), pageRequest);
 		}
 
+		Map<Long, ReplyPreviewDto> replyPreviewByParentId =
+				buildReplyPreviewByParentId(page.getContent());
+
 		return page.getContent().stream().sorted(java.util.Comparator.comparing(Message::getId))
-				.map(msg -> toWrappedShortMessage(msg, EventType.MESSAGE)).toList();
+				.map(msg -> toWrappedShortMessage(msg, EventType.MESSAGE,
+						replyPreviewByParentId.get(msg.getReplyToMessageId())))
+				.toList();
 
 	}
 
@@ -389,8 +408,13 @@ public class MessageService {
 			return new ArrayList<>();
 		}
 
-		return messageRepository.findByRoomIdAndDeletedAtIsNullOrderBySentAtAsc(privateRoom.getId())
-				.stream().map(message -> mapToMessageResponse(message, privateRoom.getId()))
+		List<Message> messages =
+				messageRepository.findByRoomIdAndDeletedAtIsNullOrderBySentAtAsc(privateRoom.getId());
+		Map<Long, ReplyPreviewDto> replyPreviewByParentId = buildReplyPreviewByParentId(messages);
+
+		return messages.stream()
+				.map(message -> mapToMessageResponse(message, privateRoom.getId(),
+						replyPreviewByParentId.get(message.getReplyToMessageId())))
 				.toList();
 	}
 
@@ -408,14 +432,15 @@ public class MessageService {
 
 	// ===== PRIVATE HELPER METHODS =====
 
-	private Message createMessage(User sender, String content, Room room, Channel channel) {
+	private Message createMessage(User sender, String content, Room room, Channel channel,
+			Long replyToMessageId) {
 		Message message = new Message();
 		message.setSender(sender);
 		message.setContent(content);
 		message.setType(MessageType.DEFAULT);
 		message.setRoom(room);
 		message.setChannel(channel);
-		message.setReplyToMessageId(null);
+		message.setReplyToMessageId(replyToMessageId);
 		message.setEditedAt(null);
 		message.setDeletedAt(null);
 		message.setSentAt(LocalDateTime.now());
@@ -423,16 +448,24 @@ public class MessageService {
 	}
 
 	private ShortMessageWrapped toWrappedShortMessage(Message message, EventType eventType) {
+		ReplyPreviewDto replyPreview = resolveReplyPreview(message.getReplyToMessageId());
+		return toWrappedShortMessage(message, eventType, replyPreview);
+	}
+
+	private ShortMessageWrapped toWrappedShortMessage(Message message, EventType eventType,
+			ReplyPreviewDto replyPreview) {
 		SenderDto sender = new SenderDto(message.getSender().getId(),
 				message.getSender().getUsername(), message.getSender().getDisplayName(),
 				message.getSender().getAvatarUrl(), message.getSender().getStatus());
 		RoomShortDto room =
 				new RoomShortDto(message.getRoom().getId(), message.getRoom().getType());
 		return new ShortMessageWrapped(message.getId(), message.getContent(), message.getType(),
-				eventType, message.getSentAt(), sender, room, message.getEditedAt());
+				eventType, message.getSentAt(), sender, room, message.getEditedAt(),
+				message.getReplyToMessageId(), replyPreview);
 	}
 
-	private MessageResponse mapToMessageResponse(Message message, Long roomId) {
+	private MessageResponse mapToMessageResponse(Message message, Long roomId,
+			ReplyPreviewDto replyPreview) {
 		MessageResponse response = new MessageResponse();
 		response.setId(message.getId());
 		response.setContent(message.getContent());
@@ -440,6 +473,8 @@ public class MessageService {
 		response.setSentAt(message.getSentAt());
 		response.setMessageType(message.getType());
 		response.setRoomId(roomId);
+		response.setReplyToMessageId(message.getReplyToMessageId());
+		response.setReplyPreview(replyPreview);
 		return response;
 	}
 
@@ -457,8 +492,101 @@ public class MessageService {
 		response.setType(message.getType());
 		response.setChannelId(channel.getId());
 		response.setEventType(eventType);
+		response.setReplyToMessageId(message.getReplyToMessageId());
+		response.setReplyPreview(resolveReplyPreview(message.getReplyToMessageId()));
 		response.setEditedAt(message.getEditedAt());
 		return response;
+	}
+
+	private void validateReplyTarget(Long replyToMessageId, Room room, Channel channel) {
+		if (replyToMessageId == null) {
+			return;
+		}
+
+		Message parent = getMessage(replyToMessageId);
+		if (parent.isDeleted()) {
+			throw new MessageTargetValidationException("Cannot reply to a deleted message");
+		}
+
+		if (room != null) {
+			if (parent.getRoom() == null || !room.getId().equals(parent.getRoom().getId())) {
+				throw new MessageTargetValidationException(
+						"Reply target message must belong to the same room");
+			}
+			return;
+		}
+
+		if (channel != null && (parent.getChannel() == null
+				|| !channel.getId().equals(parent.getChannel().getId()))) {
+			throw new MessageTargetValidationException(
+					"Reply target message must belong to the same channel");
+		}
+	}
+
+	private Map<Long, ReplyPreviewDto> buildReplyPreviewByParentId(List<Message> messages) {
+		Set<Long> replyToIds = new HashSet<>();
+		for (Message message : messages) {
+			if (message.getReplyToMessageId() != null) {
+				replyToIds.add(message.getReplyToMessageId());
+			}
+		}
+
+		if (replyToIds.isEmpty()) {
+			return Map.of();
+		}
+
+		Map<Long, Message> parentById = new HashMap<>();
+		for (Message parent : messageRepository.findAllById(replyToIds)) {
+			parentById.put(parent.getId(), parent);
+		}
+
+		Map<Long, ReplyPreviewDto> previewByParentId = new HashMap<>();
+		for (Long replyToId : replyToIds) {
+			Message parent = parentById.get(replyToId);
+			if (parent == null) {
+				previewByParentId.put(replyToId, buildMissingReplyPreview(replyToId));
+			} else {
+				previewByParentId.put(replyToId, buildReplyPreview(parent));
+			}
+		}
+
+		return previewByParentId;
+	}
+
+	private ReplyPreviewDto resolveReplyPreview(Long replyToMessageId) {
+		if (replyToMessageId == null) {
+			return null;
+		}
+
+		return messageRepository.findById(replyToMessageId).map(this::buildReplyPreview)
+				.orElseGet(() -> buildMissingReplyPreview(replyToMessageId));
+	}
+
+	private ReplyPreviewDto buildReplyPreview(Message parent) {
+		boolean deleted = parent.isDeleted();
+		String snippet = deleted ? null : buildSnippet(parent.getContent());
+
+		return new ReplyPreviewDto(parent.getId(), parent.getSender().getId(),
+				parent.getSender().getUsername(), parent.getSender().getDisplayName(), snippet,
+				parent.getType(), deleted);
+	}
+
+	private ReplyPreviewDto buildMissingReplyPreview(Long replyToMessageId) {
+		return new ReplyPreviewDto(replyToMessageId, null, null, null, null, null, true);
+	}
+
+	private String buildSnippet(String content) {
+		if (content == null) {
+			return null;
+		}
+
+		String trimmed = content.trim();
+		int maxLength = 120;
+		if (trimmed.length() <= maxLength) {
+			return trimmed;
+		}
+
+		return trimmed.substring(0, maxLength) + "...";
 	}
 
 	private void buildFailedMessage(Exception e, String action, long durationStart, Room room,
@@ -531,4 +659,3 @@ public class MessageService {
 		}
 	}
 }
-


### PR DESCRIPTION
### Motivation

- Provide minimal backend support for single-parent message replies (no threads/tree) using the existing `Message.replyToMessageId` field.
- Keep backward compatibility for WebSocket send payloads (plain string) and preserve existing websocket event types and message flow.

### Description

- Accept WS send payload as either legacy text or JSON object with `content` and `replyToMessageId` (alias `parentMessageId`) by adding `WebSocketMessageRequest` and parsing in `ChatController`.
- Persist `replyToMessageId` on create and validate parent existence, non-deleted state and same room/channel context in `MessageService` via `validateReplyTarget`.
- Add compact reply preview DTO `ReplyPreviewDto` and include `replyToMessageId` + `replyPreview` in outgoing DTOs: `ShortMessageWrapped`, `ChannelMessageResponse` and `MessageResponse` for history and realtime payloads.
- Batch-load parent messages for history pages to avoid N+1 (`buildReplyPreviewByParentId`) and provide predictable fallback preview when parent is missing or deleted.
- Extend `ChannelService` to include reply preview in channel history responses, and add `docs/message-replies-backend-notes.md` documenting flow, edge cases and manual checks.
- No schema migration was required because `replyToMessageId` already exists and is nullable.

### Testing

- Ran `git status --short` to verify changes were staged and committed successfully; commit created for the patch.  
- Attempted to run build with `./mvnw -q -DskipTests compile` but it failed in this environment due to wrapper permission/network issues, so no project compile or automated tests were executed here.  
- Manual verification checklist was added to `docs/message-replies-backend-notes.md` for local runtime and integration testing (listed steps to exercise WS formats, history endpoints, validation and deleted-parent behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6782ad3f0832e912fadcef1441db2)